### PR TITLE
Fixes CMakeLists.txt to properly import the paths into any location. pico-sdk compatible.

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -41,6 +41,7 @@ target_compile_definitions(tcMenu
 
 target_include_directories(tcMenu PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/../src
+        ${CMAKE_CURRENT_LIST_DIR}/../src/graphics
 )
 
 target_link_libraries(tcMenu PUBLIC pico_stdlib pico_sync IoAbstraction TaskManagerIO tcUnicodeHelper)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(tcMenu INTERFACE
+add_library(tcMenu 
         ../src/BaseDialog.cpp
         ../src/BaseRenderers.cpp
         ../src/EditableLargeNumberMenuItem.cpp
@@ -36,11 +36,11 @@ add_library(tcMenu INTERFACE
 )
 
 target_compile_definitions(tcMenu
-        INTERFACE BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
+        PUBLIC BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
 )
 
-target_include_directories(tcMenu INTERFACE
+target_include_directories(tcMenu PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/../src
 )
 
-target_link_libraries(tcMenu INTERFACE pico_stdlib pico_sync IoAbstraction TaskManagerIO tcUnicodeHelper)
+target_link_libraries(tcMenu PUBLIC pico_stdlib pico_sync IoAbstraction TaskManagerIO tcUnicodeHelper)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -40,7 +40,7 @@ target_compile_definitions(tcMenu
 )
 
 target_include_directories(tcMenu PUBLIC
-        ${PROJECT_SOURCE_DIR}/lib/tcMenu/src
+        ${CMAKE_CURRENT_LIST_DIR}/../src
 )
 
 target_link_libraries(tcMenu PUBLIC pico_stdlib pico_sync IoAbstraction TaskManagerIO tcUnicodeHelper)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(tcMenu
+add_library(tcMenu INTERFACE
         ../src/BaseDialog.cpp
         ../src/BaseRenderers.cpp
         ../src/EditableLargeNumberMenuItem.cpp
@@ -36,12 +36,11 @@ add_library(tcMenu
 )
 
 target_compile_definitions(tcMenu
-        PUBLIC BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
+        INTERFACE BUILD_FOR_PICO_CMAKE=1 BUILD_PICO_FORCE_UART=1 IO_LOGGING_DEBUG=1
 )
 
-target_include_directories(tcMenu PUBLIC
+target_include_directories(tcMenu INTERFACE
         ${CMAKE_CURRENT_LIST_DIR}/../src
-        ${CMAKE_CURRENT_LIST_DIR}/../src/graphics
 )
 
-target_link_libraries(tcMenu PUBLIC pico_stdlib pico_sync IoAbstraction TaskManagerIO tcUnicodeHelper)
+target_link_libraries(tcMenu INTERFACE pico_stdlib pico_sync IoAbstraction TaskManagerIO tcUnicodeHelper)

--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -1,3 +1,5 @@
+cmake_minimum_required(VERSION 3.13)
+
 add_library(tcMenu 
         ../src/BaseDialog.cpp
         ../src/BaseRenderers.cpp
@@ -40,7 +42,7 @@ target_compile_definitions(tcMenu
 )
 
 target_include_directories(tcMenu PUBLIC
-        ${CMAKE_CURRENT_LIST_DIR}/../src
+        ../src
 )
 
 target_link_libraries(tcMenu PUBLIC pico_stdlib pico_sync IoAbstraction TaskManagerIO tcUnicodeHelper)


### PR DESCRIPTION
In trying out the tcMenu, i found it not easy to use as the libraries had to be exported and pushed into very specific locations. Having done cmake libraries for the pico-sdk, I was able to make the required changes to properly import the sdk using cmake.

The `CMakeLists.txt` has had the paths fixed,  so that it can be used with the `libraries.cmake` that is in the `tcLibraryDev` or `FetchContent`  from cmake.